### PR TITLE
libs/gui: Release acquired buffer when createImage fails

### DIFF
--- a/libs/gui/GLConsumer.cpp
+++ b/libs/gui/GLConsumer.cpp
@@ -380,6 +380,8 @@ status_t GLConsumer::updateAndReleaseLocked(const BufferQueue::BufferItem& item)
         if (image == EGL_NO_IMAGE_KHR) {
             ST_LOGW("updateAndRelease: unable to createImage on display=%p slot=%d",
                   mEglDisplay, buf);
+            releaseBufferLocked(buf, mSlots[buf].mGraphicBuffer,
+                                mEglDisplay, EGL_NO_SYNC_KHR);
             return UNKNOWN_ERROR;
         }
         mEglSlots[buf].mEglImage = image;


### PR DESCRIPTION
When EGL fails to create an KHR image for an acquired buffer,
release the buffer before returning with error. This unblocks
the dequeue buffer call waiting and may succeed in the next queue.

CRs-Fixed: 624244

Change-Id: I674807f4bb1f1253cb787daaa5a7adf351caaae7
(cherry picked from commit 9e9b12d7f37a6120a705db56a4374e7141c79a41)
